### PR TITLE
Do not close the application after an action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     name: Release
     steps:
-      - name: Set up Go 1.14
+      - name: Setup Go 1.15
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.15
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -49,7 +49,7 @@ func SelectAlert(cfg config.Config, alerts []alert.GetAlertResult) (alert.GetAle
 func SelectAction(a alert.GetAlertResult) (string, error) {
 	prompt := promptui.Select{
 		Label:  "Action for " + a.Message,
-		Items:  []string{"Acknowledge", "Close", "Snooze", "Quit Opsgenie"},
+		Items:  []string{"Acknowledge", "Close", "Snooze", "Cancel"},
 		Stdout: &bellSkipper{},
 	}
 


### PR DESCRIPTION
Until now the application was closed when a user selected an action. Now
we are reloading the list of alerts and show it again. For that the **Quit Opsgenie** action was renamed to **Cancel**. To close the application a user can still use `Ctrl + C`. The error message which always was shown when the application was closed, is now also removed.